### PR TITLE
Don't clear cache when destroying history

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ cache:
   directories:
     - ~/.yarn
     - ~/.nvm
+sudo: required # https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-348227535
+addons:
+  chrome: stable

--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -123,7 +123,6 @@ class History {
     if (this.running) {
       window.removeEventListener('click', this.onClick, false);
       window.removeEventListener('popstate', this.onPopstate, false);
-      this.cache = null;
       this.running = false;
     }
   }


### PR DESCRIPTION
Users of the history library could potentially attempt to use the library
after it's destroyed and before we have finished redirecting to the new page.

`history.getCurrentContext()` should for example continue to work.